### PR TITLE
DataTypeHandler: use getsectiondata instead of getsectdata

### DIFF
--- a/dspci/DataTypeHandler.m
+++ b/dspci/DataTypeHandler.m
@@ -15,6 +15,8 @@
 
 #import "Tables.h"
 
+#import <mach-o/ldsyms.h>
+
 #define kPCIFormat @"%04lX:%04lX"
 
 @implementation DataTypeHandler
@@ -95,7 +97,8 @@
  */
 - (NSString *) loadPCIIDs {
     unsigned long len;
-    char *handle = strdup(getsectdata("__TEXT", "__pci_ids", &len));
+    const struct mach_header_64 *mh = &_mh_execute_header;
+    char *handle = strdup((char *) getsectiondata(mh, "__TEXT", "__pci_ids", &len));
     NSNumber *currentClass;
     NSNumber *currentVendor;
     char buffer[LINE_MAX];


### PR DESCRIPTION
Fixes a segfault on arm64 caused by getsectdata giving an invalid pointer.

I'll be honest that I do not know much C or ObjC and this is suggected to me by ChatGPT. I did test this compiled for both arm64 and x86_64 and it works fine.